### PR TITLE
Make copy-files.sh fail if any copy step fails

### DIFF
--- a/share/WinGit/copy-files.sh
+++ b/share/WinGit/copy-files.sh
@@ -97,6 +97,6 @@ cp $MSYSGITROOT/src/git-cheetah/explorer/git_shell_ext64.dll git-cheetah/ &&
 cp $MSYSGITROOT/share/WinGit/ReleaseNotes.rtf . &&
 sed 's/^\. .*\(git-completion.bash\)/. \/etc\/\1/' \
 	< $MSYSGITROOT/etc/profile > etc/profile &&
-cp $MSYSGITROOT/share/resources/git.ico etc/ ||
+cp $MSYSGITROOT/share/resources/git.ico etc/ &&
 find bin libexec -iname \*.exe -o -iname \*.dll | sort > etc/fileList-bindimage.txt ||
 exit 1


### PR DESCRIPTION
Things used to work this way back before baa94345e2a0c526cb32654d91724ca0275d3053, but a bad merge in that commit caused this behavior to be lost.
