### PR TITLE
fix zlib 1.2.6 not available from serve anymore

### DIFF
--- a/src/mingw-w64/release-zlib.sh
+++ b/src/mingw-w64/release-zlib.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"
 srcdir=$(pwd)
 
 mirror=http://zlib.net/
-file=zlib-1.2.6.tar.gz
+file=zlib-1.2.7.tar.gz
 dir=${file%.tar.gz}
 
 # download it


### PR DESCRIPTION
curl http://zlib.net/zlib-1.2.6.tar.gz
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>

<h1>Not Found</h1>

<p>The requested URL /zlib-1.2.6.tar.gz was not found on this server.</p>

<p>Additionally, a 404 Not Found
error was encountered while trying to use an ErrorDocument to handle the request.</p>

<hr>

<address>Apache/2.2.21 (Unix) mod_ssl/2.2.21 OpenSSL/0.9.7a mod_auth_passthrough/2.1 mod_bwlimited/1.4 FrontPage/5.0.2.2635 Server at zlib.net Port 80</address>
</body></html>
