### PR TITLE
Attempted fix for issue with context-menu entries on XPx64/Server2003x64

### DIFF
--- a/share/WinGit/install.iss
+++ b/share/WinGit/install.iss
@@ -1115,7 +1115,7 @@ begin
 
     if IsComponentSelected('ext\reg\shellhere') then begin
         if (not RegWriteStringValue(RootKey,'SOFTWARE\Classes\Directory\shell\git_shell','','Git Ba&sh Here')) or
-           (not RegWriteStringValue(RootKey,'SOFTWARE\Classes\Directory\shell\git_shell\command','','wscript "'+AppDir+'\Git Bash.vbs" "%1"')) then begin
+           (not RegWriteStringValue(RootKey,'SOFTWARE\Classes\Directory\shell\git_shell\command','','"'+ExpandConstant('{syswow64}')+'\wscript" "'+AppDir+'\Git Bash.vbs" "%1"')) then begin
             Msg:='Line {#__LINE__}: Unable to create "Git Bash Here" shell extension.';
             MsgBox(Msg,mbError,MB_OK);
             Log(Msg);


### PR DESCRIPTION
See http://stackoverflow.com/questions/10450550/msysgit-fork-cant-reserve-memory-for-stack/10639268#10639268

I did not test this, however, I made a similar adaptation in my project https://github.com/rpavlik/git-windows-mintty/blob/master/setup.iss#L61 that both fixed the issue on XP x64, and works correctly on Win7 x64.
