### PR TITLE
Issue #16 workaround:  Added steps to the installer to create git-upload-pack.exe and git-receive-pack.exe hard links

### DIFF
--- a/share/WinGit/install.iss
+++ b/share/WinGit/install.iss
@@ -891,6 +891,26 @@ begin
         // aliases for built-ins, so we continue.
     end;
 
+    // Create a git-upload-pack.exe hard link in the bin folder
+    FileName := AppDir + '\bin\git-upload-pack.exe'
+    try
+      LinkCreated := CreateHardLink(FileName, AppDir + '\libexec\git-core\git-upload-pack.exe', 0);
+    except
+      LinkCreated := False;
+    end;
+    if not LinkCreated then
+      Log('Line {#__LINE__}: Creating hardlink "' + FileName + '" failed.');
+
+    // Create a git-receive-pack.exe hard link in the bin folder
+    FileName := AppDir + '\bin\git-receive-pack.exe'
+    try
+      LinkCreated := CreateHardLink(FileName, AppDir + '\bin\git.exe', 0);
+    except
+      LinkCreated := False;
+    end;
+    if not LinkCreated then
+      Log('Line {#__LINE__}: Creating hardlink "' + FileName + '" failed.');
+
     {
         Adapt core.autocrlf
     }


### PR DESCRIPTION
Issue #16 workaround:  Added steps to the installer to create git-upload-pack.exe and git-receive-pack.exe hard links in the \bin folder.  This fixes the error that may occur when attempting to push to a repository hosted on a Windows Vista (or later) server due to an apparent compatibility issue between CopSSH and symbolic links.

Signed-off-by: Pierre le Riche github@pleasedontspam.me
