### PR TITLE
Bash PS1 fixes and refactoring.

### DIFF
--- a/etc/profile
+++ b/etc/profile
@@ -153,19 +153,20 @@ esac
 
 . /git/contrib/completion/git-completion.bash
 
-PS1='\[\033]0;'                # VT100 compat: reset all colors
+# non-printable characters must be enclosed inside \[ and \]
+PS1='\[\033[0m\]'              # VT100 compat: reset all colors
 PS1="$PS1"'$MSYSTEM:\w'        # e.g. MINGW32:/path/to/cwd
-PS1="$PS1"'\007'               # Ascii character BEL
+PS1="$PS1"'\[\007\]'           # Ascii character BEL
 PS1="$PS1"'\n'                 # new line
-PS1="$PS1"'\033[32m\]'         # change color
+PS1="$PS1"'\[\033[32m\]'       # change color
 PS1="$PS1"'\u@\h '             # user@host<space>
-PS1="$PS1"'\[\033[33m'         # change color
+PS1="$PS1"'\[\033[33m\]'       # change color
 PS1="$PS1"'\w'                 # current working directory
 if test -z "$WINELOADERNOEXEC"
 then
 	PS1="$PS1"'$(__git_ps1)'   # bash function
 fi
-PS1="$PS1"'\033[0m\]'          # change color
+PS1="$PS1"'\[\033[0m\]'        # change color
 PS1="$PS1"'\n'                 # new line
 PS1="$PS1"'$ '                 # prompt: always $
 


### PR DESCRIPTION
- fixed enclosing of non-printable characters (`\[`..`\]`).
- made section more readable; split PS1 into small components
- Made the scope of the `if` conditional small to make it more understandable.
