### PR TITLE
Add git subtree subcommand to default distribution

### DIFF
--- a/share/WinGit/release.sh
+++ b/share/WinGit/release.sh
@@ -76,6 +76,8 @@ test "$do_compile" && {
 			git add share/WinGit/ReleaseNotes.rtf &&
 			git commit -m "Git for Windows $version"
 		 fi) &&
+		(cd git/contrib/subtree &&
+			make install INSTALL=/bin/install prefix=) &&
 		(cd git &&
 		 create_msysgit_tag $version &&
 		 make install) &&


### PR DESCRIPTION
The git subtree subcommand is now part of the official git repository.
This tweak ensures that msysgit provides support for the command out
of the box without end-user interaction.

Signed-off-by: ciaranj ciaranj@gmail.com
