### PR TITLE
Replace git: protocol with more permissive https: protocol to allow use behind firewalls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "git"]
 	path = git
-	url = git://github.com/msysgit/git.git
+	url = https://github.com/msysgit/git.git
 [submodule "html"]
 	path = doc/git/html
-	url = git://github.com/gitster/git-htmldocs.git
+	url = https://github.com/gitster/git-htmldocs.git
 [submodule "git-cheetah"]
 	path = src/git-cheetah
-	url = git://github.com/msysgit/Git-Cheetah.git
+	url = https://github.com/msysgit/Git-Cheetah.git

--- a/share/msysGit/initialize.sh
+++ b/share/msysGit/initialize.sh
@@ -7,7 +7,7 @@ test -d /git/.git || {
 	git init &&
 	git config core.autocrlf false &&
 	git remote add -f origin \
-		git://github.com/msysgit/git &&
+		https://github.com/msysgit/git &&
 	if test ! -f /etc/full-git-sha1 ||
 		! git reset $(cat /etc/full-git-sha1)
 	then
@@ -23,7 +23,7 @@ test -d /.git || {
 	cd / &&
 	git init &&
 	git config core.autocrlf false &&
-	git remote add -f origin git://github.com/msysgit/msysgit &&
+	git remote add -f origin https://github.com/msysgit/msysgit &&
 	if test ! -f /etc/full-msysgit-sha1 ||
 		! git reset $(cat /etc/full-msysgit-sha1)
 	then


### PR DESCRIPTION
Downloading msysgit behind corporate firewalls that allow only http/https traffic doesn't allow the git protocol to be used for submodules, so use the https protocol instead.
