### PR TITLE
Improved cygwin path-stripping code

### DIFF
--- a/etc/profile
+++ b/etc/profile
@@ -24,10 +24,8 @@ fi
 # strip out cygwin paths from PATH
 case "$PATH" in
 */cygwin/*)
-	PATH="$(awk -vRS=: -vORS=: '!/cygwin/' <<< "$PATH")"
-	# awk always adds a trailing separator
-	export PATH="${PATH%:}"
-	;;
+  export PATH=$(IFS=':'; t=($PATH); unset IFS; t=(${t[@]%%*/cygwin/*}); IFS=':'; echo "${t[*]}")
+  ;;
 esac
 
 if [ -z "$USERNAME" ]; then


### PR DESCRIPTION
Using awk to strip the cygwin paths creates a null-byte at the end of the string, meaning that the last path cannot be found. This routine avoids using awk to resolve this issue.

See Issue: #67
