### PR TITLE
compile and integrate windows credential helper into installer

### DIFF
--- a/etc/gitconfig
+++ b/etc/gitconfig
@@ -6,6 +6,8 @@
 	status = auto
 	branch = auto
 	interactive = true
+[credential]
+	helper = wincred
 [pack]
 	packSizeLimit = 2g
 [help]

--- a/share/WinGit/copy-files.sh
+++ b/share/WinGit/copy-files.sh
@@ -87,6 +87,8 @@ cp $MSYSGITROOT/mingw/bin/hd2u.exe bin/dos2unix.exe &&
 strip bin/{[a-fh-z],g[a-oq-z]}*.exe libexec/git-core/*.exe &&
 cp $MSYSGITROOT/git/contrib/completion/git-completion.bash etc/ &&
 cp $MSYSGITROOT/git/contrib/completion/git-prompt.sh etc/ &&
+cp $MSYSGITROOT/git/contrib/credential/wincred/git-credential-wincred.exe \
+	bin/git-credential-wincred.exe &&
 cp $MSYSGITROOT/etc/termcap etc/ &&
 cp $MSYSGITROOT/etc/inputrc etc/ &&
 sed 's/ = \/mingw\// = \//' < $MSYSGITROOT/etc/gitconfig > etc/gitconfig &&

--- a/share/WinGit/release.sh
+++ b/share/WinGit/release.sh
@@ -76,6 +76,7 @@ test "$do_compile" && {
 			git add share/WinGit/ReleaseNotes.rtf &&
 			git commit -m "Git for Windows $version"
 		 fi) &&
+		(cd git/contrib/credential/wincred && make) &&
 		(cd git/contrib/subtree &&
 			make install INSTALL=/bin/install prefix=) &&
 		(cd git &&


### PR DESCRIPTION
Gits source now contains an implementation for the windows credential
API. Lets teach git to remember usernames and passwords using this
helper.

Signed-off-by: Heiko Voigt heiko.voigt@mahr.de

This implements the request reported here:
https://github.com/msysgit/git/issues/35
