### PR TITLE
copy-files.sh: libexec/gnupg/ doesn't exist anymore

### DIFF
--- a/share/WinGit/copy-files.sh
+++ b/share/WinGit/copy-files.sh
@@ -81,7 +81,7 @@ fi &&
 	bin/getcp.exe bin/rebase.exe \
 	bin/gzip.exe bin/gunzip.exe \
 	bin/{libpoppler-7.dll,pdfinfo.exe,pdftotext.exe} \
-	lib/{tcl,tk,dde,reg}* libexec/gnupg/) |
+	lib/{tcl,tk,dde,reg}* ) |
 tar xf - &&
 cp $MSYSGITROOT/mingw/bin/hd2u.exe bin/dos2unix.exe &&
 strip bin/{[a-fh-z],g[a-oq-z]}*.exe libexec/git-core/*.exe &&


### PR DESCRIPTION
Commit 8905816 updated GNUPG and moved the helper executables from
mingw/libexec/gnupg to mingw/bin but didn't update the copy script
in share/WinGit.

Signed-off-by: Stefan Naewe stefan.naewe@gmail.com
