### PR TITLE
bash_profile: use auto colors to avoid ESC in redirections

### DIFF
--- a/etc/bash_profile
+++ b/etc/bash_profile
@@ -2,6 +2,6 @@
 # creates his/her own .bashrc/.bash_profile
 
 # --show-control-chars: help showing Korean or accented characters
-alias ls='ls -F --color --show-control-chars'
+alias ls='ls -F --color=auto --show-control-chars'
 alias ll='ls -l'
 


### PR DESCRIPTION
Piping the result of the `ls` command (alias) to a file will contain escape characters because the `--color` setting for `ls` is defaulting to `--color=always` instead of `--color=auto` (auto means, it will only produce color control codes on a real tty)
