### PR TITLE
merging-rebase: set both GIT_SEQUENCE_EDITOR and GIT_EDITOR to modify the insn-cheet

### DIFF
--- a/share/msysGit/merging-rebase.sh
+++ b/share/msysGit/merging-rebase.sh
@@ -180,4 +180,4 @@ EOF
 chmod a+x "$TMP_EDITOR"
 
 # Rebase!
-GIT_EDITOR="$TMP_EDITOR" git rebase --autosquash -i ${REBASING_BASE:-$TO}
+GIT_EDITOR="$TMP_EDITOR" GIT_SEQUENCE_EDITOR="$TMP_EDITOR" git rebase --autosquash -i ${REBASING_BASE:-$TO}


### PR DESCRIPTION
Somehow git rebase -i seems to ignore GIT_EDITOR and only uses
GIT_SEQUENCE_EDITOR. Set both variables to not introduce a regression.

Signed-off-by: Stefan Naewe stefan.naewe@gmail.com
