### PR TITLE
Fix issue #128: Git Bash: avoid beeps, if $PWD contains non ASCII chars

### DIFF
--- a/etc/profile
+++ b/etc/profile
@@ -153,7 +153,7 @@ esac
 [ -r /git/contrib/completion/git-prompt.sh ] && . /git/contrib/completion/git-prompt.sh
 
 # non-printable characters must be enclosed inside \[ and \]
-PS1='\[\033]0;$MSYSTEM:\w\007\]' # set window title
+PS1='\[\033]0;$MSYSTEM:${PWD//[^[:ascii:]]/?}\007\]' # set window title
 PS1="$PS1"'\n'                 # new line
 PS1="$PS1"'\[\033[32m\]'       # change color
 PS1="$PS1"'\u@\h '             # user@host<space>


### PR DESCRIPTION
This is the pull request for issue #128. 

This patch changes the PS1 prompt. The PS1 prompt emits a control sequence that sets the window title to the current directory. If the path to the current directory contains non ASCII characters, the console window beeps.

This patch replaces non ASCII characters by a '?' in the window title. The patch uses the ${///} variable expansion syntax and does not execute an external process. Therefore it should not degrade the performance.
