### PR TITLE
Allow to change current drive in addition to current directory

### DIFF
--- a/git-cmd.bat
+++ b/git-cmd.bat
@@ -12,5 +12,5 @@
 @set PLINK_PROTOCOL=ssh
 @if not defined TERM set TERM=msys
 
-@cd %HOME%
+@cd /d %HOME%
 @start %COMSPEC%


### PR DESCRIPTION
In case the `%HOME%` directory is not located on the same drive as msysgit, `git-cmd.bat` will not open at the correct location. To fix this, `git-cmd.bat` needs to use the `/d` option to change into the home directory.
