### PR TITLE
update submodule urls for msys branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "git"]
 	path = git
-	url = git://repo.or.cz/git/mingw/4msysgit.git/
+	url = ../git.git
 [submodule "html"]
 	path = doc/git/html
 	url = git://git.kernel.org/pub/scm/git/git.git
 [submodule "git-cheetah"]
 	path = src/git-cheetah
-	url = git://repo.or.cz/git-cheetah.git/
+	url = ../Git-Cheetah.git
 [submodule "src/msys"]
 	path = src/msys
-	url = git://repo.or.cz/msys.git
+	url = ../msys.git


### PR DESCRIPTION
We have moved all our repositories to github some time ago. While
changing them lets also make them relative for fork convenience.

Signed-off-by: Heiko Voigt hvoigt@hvoigt.net
