### PR TITLE
Fix zlib 1.2.7 not available from server anymore

### DIFF
--- a/src/mingw-w64/release-zlib.sh
+++ b/src/mingw-w64/release-zlib.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"
 srcdir=$(pwd)
 
 mirror=http://zlib.net/
-file=zlib-1.2.7.tar.gz
+file=zlib-1.2.8.tar.gz
 dir=${file%.tar.gz}
 
 die () {


### PR DESCRIPTION
Only the current version, 1.2.8, is available,
curl http://zlib.net/zlib-1.2.7.tar.gz
returns a 404 Not Found.
