### PR TITLE
Perl readline creates empty sys$command files if no STDIN is connected

### DIFF
--- a/lib/perl5/5.8.8/Term/ReadLine.pm
+++ b/lib/perl5/5.8.8/Term/ReadLine.pm
@@ -214,7 +214,7 @@ sub findConsole {
         $console = "Dev:Console";
     } elsif (-e "/dev/tty") {
 	$console = "/dev/tty";
-    } elsif (-e "con" or $^O eq 'MSWin32') {
+    } elsif (-e "con" or $^O eq 'MSWin32' or $^O eq 'msys') {
 	$console = "con";
     } else {
 	$console = "sys\$command";


### PR DESCRIPTION
This was originally reported to TortoiseGit: http://code.google.com/p/tortoisegit/issues/detail?id=1011

This patch was also reported to msysgit (https://groups.google.com/forum/#!topic/msysgit/oHDBhnAHIe4), MinGW (http://sourceforge.net/p/mingw/patches/506/) and upstream perl (https://rt.perl.org//Public/Bug/Display.html?id=115900) where it was finally accepted and applied (to version 5.18).

It was already reported one year ago (https://groups.google.com/forum/#!topic/msysgit/oHDBhnAHIe4 and https://github.com/msysgit/msysgit/issues/61#issuecomment-10695361).

https://github.com/msysgit/msysgit/issues/61#issuecomment-31372100 states that I should create a PR, so I do.
