### PR TITLE
Installer: Detect TortoiseGitPLink from TortoiseGit

### DIFF
--- a/share/WinGit/putty.inc.iss
+++ b/share/WinGit/putty.inc.iss
@@ -10,6 +10,7 @@ const
 // Tries to detect the path to a PuTTY installation / an application that comes
 // with an improved version of Plink. TortoisePlink from TortoiseGit/SVN features a
 // GUI dialog to accept new host keys, for example.
+// Prefer TortoiseGitPlink (optimized for Git) over TortoisePlink.
 function GuessPlinkExecutable:string;
 begin
     // Prefer TortoisePlink over vanilla Plink for its GUI dialog to accept host keys.
@@ -31,6 +32,11 @@ begin
     end;
 
     if DirExists(Result) then begin
+        if FileExists(Result+'TortoiseGitPlink.exe') then begin
+            Result:=Result+'TortoiseGitPlink.exe'
+            Exit;
+        end;
+
         Result:=Result+'TortoisePlink.exe'
         Exit;
     end;


### PR DESCRIPTION
TortoiseGit comes with a Git optimized version of TortoisePlink called TortoiseGitPLink. A new name was chosen so that TortoisePLink provides the exact same results as the TortoiseSVN version.

Main change to TortoiseGitPLink is that the "-batch" parameter which causes problems in TortoisePLink, but is required for vanilla plink, is ignored (see http://code.google.com/p/tortoisegit/issues/detail?id=1617).
