### PR TITLE
MSYS branch: add missing git-prompt.sh in /etc/profile

### DIFF
--- a/etc/profile
+++ b/etc/profile
@@ -138,6 +138,7 @@ esac
 
 
 . /git/contrib/completion/git-completion.bash
+. /git/contrib/completion/git-prompt.sh
 PS1='\[\033]0;$MSYSTEM:\w\007
 \033[32m\]\u@\h \[\033[33m\w$(__git_ps1)\033[0m\]
 $ '


### PR DESCRIPTION
This is a fix for the `msys` branch.

Add missing reference `git-prompt.sh` that provides `__git_ps1` for `$PS1`.
