### PR TITLE
MSYS branch: get /.gitignore from master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ libexec/git-core
 /share/git-gui
 /share/gitk
 /share/git-core
-/share/perl/perl-*
 /lib/Error.pm
 /lib/Git.pm
+/lib/Git/*.pm
+/lib/Git/SVN/
+/lib/perl5/5.8.8/CPAN/Config.pm*
+/share/gitweb/
+
+# see https://github.com/msysgit/msysgit/wiki/Vagrant
+/.vagrant/


### PR DESCRIPTION
As requested in [#190](../issues/190#issuecomment-40872606):

Get `.gitignore` from 13744e0412652f497a5a79283a24e54aa630a00d (latest change of the file on the 'master' branch) and push it on msys branch. Cherry-picking was not possible because the commits concerned other files than .gitignore.
