### PR TITLE
--force: Propagate to shears.sh

### DIFF
--- a/share/msysGit/merging-rebase.sh
+++ b/share/msysGit/merging-rebase.sh
@@ -23,7 +23,7 @@ while test $# -gt 0
 do
 	case "$1" in
 	-f|--force)
-		force=t
+		force=--force
 		;;
 	-s|--show|-d|--dry-run)
 		dryrun=t
@@ -152,4 +152,4 @@ then
 	exit
 fi
 
-exec "$(dirname "$0")"/shears.sh --merging --onto=$TO ${REBASING_BASE:-$TO}
+exec "$(dirname "$0")"/shears.sh $force --merging --onto=$TO ${REBASING_BASE:-$TO}


### PR DESCRIPTION
After an annoying mistake and subsequent abort during a merging-rebase, I used the --force only to be stopped by a message from shears.sh telling me to use --force.

(As a side note, this commit could only have been made more amusing by submitting it yesterday...)
