### PR TITLE
Add openssh patch to suppress errors on XP

### DIFF
--- a/src/openssh/patches/0001-Fix-man-install.patch
+++ b/src/openssh/patches/0001-Fix-man-install.patch
@@ -1,7 +1,7 @@
-From 7a9a9b75f06965b154018c9e54533347cb579a5e Mon Sep 17 00:00:00 2001
+From c2fa682c5ce2132ea0fb01f61cd953fbde782262 Mon Sep 17 00:00:00 2001
 From: Hiroshi Shirosaki <h.shirosaki@gmail.com>
 Date: Tue, 24 Jun 2014 13:43:17 +0900
-Subject: [PATCH 1/4] Fix man install
+Subject: [PATCH 1/5] Fix man install
 
 https://github.com/Alexpux/MSYS2-packages/blob/master/openssh/openssh-6.3p1-fix-man-install.patch
 ---

--- a/src/openssh/patches/0002-Fix-for-msys.patch
+++ b/src/openssh/patches/0002-Fix-for-msys.patch
@@ -1,7 +1,7 @@
-From ae9c9e8dc5a84bec785a27b78a9b1fc5b0766ad8 Mon Sep 17 00:00:00 2001
+From 78b3141ed99f65fb517666256cf4b189c7f00c4a Mon Sep 17 00:00:00 2001
 From: Hiroshi Shirosaki <h.shirosaki@gmail.com>
 Date: Tue, 24 Jun 2014 13:45:22 +0900
-Subject: [PATCH 2/4] Fix for msys
+Subject: [PATCH 2/5] Fix for msys
 
 Based on the patch.
 https://github.com/Alexpux/MSYS2-packages/blob/master/openssh/openssh-6.3p1-msys2.patch

--- a/src/openssh/patches/0003-Fix-curve25519-sha256-key-exchange-bug.patch
+++ b/src/openssh/patches/0003-Fix-curve25519-sha256-key-exchange-bug.patch
@@ -1,7 +1,7 @@
-From 23aca077bb9936ca7d78af91333c27fa2904cd2e Mon Sep 17 00:00:00 2001
+From c2e5a2c590b56e21a0d27778352b7639eed73bef Mon Sep 17 00:00:00 2001
 From: Hiroshi Shirosaki <h.shirosaki@gmail.com>
 Date: Tue, 24 Jun 2014 13:46:55 +0900
-Subject: [PATCH 3/4] Fix curve25519-sha256 key exchange bug
+Subject: [PATCH 3/5] Fix curve25519-sha256 key exchange bug
 
 https://github.com/Alexpux/MSYS2-packages/blob/master/openssh/curve25519-sha256.patch
 ---

--- a/src/openssh/patches/0004-Fix-compile-and-install-error-on-msys.patch
+++ b/src/openssh/patches/0004-Fix-compile-and-install-error-on-msys.patch
@@ -1,7 +1,7 @@
-From 79a0d6b5eaeedfdb9935be483f2c79966fca8f41 Mon Sep 17 00:00:00 2001
+From 1d550bacd145a12bc2a2db2d2880668fa585bc87 Mon Sep 17 00:00:00 2001
 From: Hiroshi Shirosaki <h.shirosaki@gmail.com>
 Date: Tue, 24 Jun 2014 15:42:28 +0900
-Subject: [PATCH 4/4] Fix compile and install error on msys
+Subject: [PATCH 4/5] Fix compile and install error on msys
 
 Based on the patch.
 https://github.com/sschuberth/mingwGitDevEnv-packages/blob/master/msys-openssh/openssh-6.6p1-1.msys.patch

--- a/src/openssh/patches/0005-Define-IP_TOS_IS_BROKEN-not-to-use-IP_TOS-option.patch
+++ b/src/openssh/patches/0005-Define-IP_TOS_IS_BROKEN-not-to-use-IP_TOS-option.patch
@@ -1,0 +1,30 @@
+From 5080680a1dba851ef8a4b6eba9aa91f4a111c9ba Mon Sep 17 00:00:00 2001
+From: Hiroshi Shirosaki <h.shirosaki@gmail.com>
+Date: Fri, 27 Jun 2014 21:15:54 +0900
+Subject: [PATCH 5/5] Define IP_TOS_IS_BROKEN not to use IP_TOS option
+
+Winsock IP_TOS option is silently ignored on Windows 7.
+http://blogs.msdn.com/b/wndp/archive/2006/07/05/657196.aspx
+
+IP_TOS option causes an error on Windows XP.
+https://groups.google.com/forum/#!topic/msysgit/2VEyHhOXEps
+---
+ configure.ac | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 9f1b966..f6fb9c1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -549,6 +549,8 @@ case "$host" in
+ 	# Cygwin defines optargs, optargs as declspec(dllimport) for historical
+ 	# reasons which cause compile warnings, so we disable those warnings.
+ 	OSSH_CHECK_CFLAG_COMPILE([-Wno-attributes])
++	AC_DEFINE([IP_TOS_IS_BROKEN], [1],
++		[Define if your system choked on IP TOS setting])
+ 	;;
+ *-*-dgux*)
+ 	AC_DEFINE([IP_TOS_IS_BROKEN], [1],
+-- 
+1.9.4.msysgit.0
+


### PR DESCRIPTION
Winsock IP_TOS option is silently ignored on Windows 7.
http://blogs.msdn.com/b/wndp/archive/2006/07/05/657196.aspx

IP_TOS option causes an error on Windows XP.
https://groups.google.com/forum/#!topic/msysgit/2VEyHhOXEps
