### PR TITLE
Sourcing bashrc and bash_profile is unnecessary

### DIFF
--- a/etc/profile
+++ b/etc/profile
@@ -173,12 +173,3 @@ export LESSCHARSET=utf-8
 
 # set default protocol for 'plink'
 export PLINK_PROTOCOL=ssh
-
-# read user-specific settings, possibly overriding anything above
-if [ -e ~/.bashrc ]; then
-    . ~/.bashrc
-elif [ -e ~/.bash_profile ]; then
-    . ~/.bash_profile
-elif [ -e /etc/bash_profile ]; then
-    . /etc/bash_profile
-fi


### PR DESCRIPTION
It is unnecessary to explicitly source these files. Bash will source them automatically. See https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html