### PR TITLE
set GIT_TEMPLATE_DIR to an empty string

### DIFF
--- a/src/common/update-lib.sh
+++ b/src/common/update-lib.sh
@@ -75,7 +75,7 @@ apply_patches () {
 	test -d "$d"/.git && return
 	patchdir="$(pwd)"/patches
 	(cd "$d" &&
-	 git init &&
+	 GIT_TEMPLATE_DIR= git init &&
 	 git config --local core.autocrlf false &&
 	 git add . &&
 	 git commit -m initial &&


### PR DESCRIPTION
This prevents git from picking up user settings of the templatedir which
might hold interferring hooks.

Signed-off-by: Thomas Braun thomas.braun@byte-physics.de
