### PR TITLE
Fix gitk.cmd to work correctly when paths contain ampersand (&) symbol

### DIFF
--- a/cmd/gitk.cmd
+++ b/cmd/gitk.cmd
@@ -1,5 +1,12 @@
 @rem Do not use "echo off" to not affect any child calls.
+
+@rem Enable extensions, the `verify other 2>nul` is a trick from the setlocal help
+@verify other 2>nul
 @setlocal enableDelayedExpansion
+@if errorlevel 1 (
+    @echo Unable to enable delayed expansion. Immediate expansion will be used.
+    @goto fallback
+)
 
 @rem Get the absolute path to the parent directory, which is assumed to be the
 @rem Git installation root.
@@ -10,3 +17,18 @@
 @if not exist "!HOME!" @set HOME=!USERPROFILE!
 
 @start "gitk" wish.exe "!git_install_root!\bin\gitk" -- %*
+@goto end
+
+:fallback
+@rem The above script again with immediate expansion, in case delayed expansion
+@rem is unavailable.
+@for /F "delims=" %%I in ("%~dp0..") do @set git_install_root=%%~fI
+@set PATH=%git_install_root%\bin;%git_install_root%\mingw\bin;%PATH%
+
+@if not exist "%HOME%" @set HOME=%HOMEDRIVE%%HOMEPATH%
+@if not exist "%HOME%" @set HOME=%USERPROFILE%
+
+@start "gitk" wish.exe "%git_install_root%\bin\gitk" -- %*
+
+:end
+@rem End of script


### PR DESCRIPTION
This is to fix the issue msysgit/git#245 I reported previously.

Assume the user profile is in `C:\Users\A&E\`.

The `gitk.cmd` script will fail in this case because `&` is recognized as joining two commands in a batch script, _unless_ if the path is double quoted.

The easiest fix for this is to use "delayed expansion" coupled with `!` (instead of `%`) to demarcate the environment variable names.

I have also enhanced the script to fall back to the original script code when delayed expansion is not available on the target computer system (in which case, a path containing ampersand may still cause the script to fail).
