### PR TITLE
include etc/motd in portable git

### DIFF
--- a/share/WinGit/portable-release.sh
+++ b/share/WinGit/portable-release.sh
@@ -19,6 +19,8 @@ TARGET7=tmp.7z
 TMPDIR=/tmp/WinGit
 
 DONT_REMOVE_BUILTINS=1 "$(dirname $0)/copy-files.sh" $TMPDIR &&
+sed -e '/share\/msysGit/d' -e "s/msysGit/Portable Git (version $version)/" \
+	< etc/motd > $TMPDIR/etc/motd &&
 cd "$TMPDIR" &&
 cp $MSYSGITROOT/share/WinGit/README.portable ./ &&
 cp $MSYSGITROOT/msys.bat ./git-bash.bat &&


### PR DESCRIPTION
Taken from [share/WinGit/release.sh](https://github.com/msysgit/msysgit/blob/master/share/WinGit/release.sh).

Before:
![1](https://cloud.githubusercontent.com/assets/1192780/4878676/e190f2b4-6315-11e4-9c37-55a964e1e4bd.PNG)

After:
![2](https://cloud.githubusercontent.com/assets/1192780/4878681/102e57ce-6316-11e4-8bba-3aa5b2d3e0af.PNG)
