### PR TITLE
Set icon background color for Windows 8 tiles

### DIFF
--- a/bin/sh.VisualElementsManifest.xml
+++ b/bin/sh.VisualElementsManifest.xml
@@ -1,0 +1,6 @@
+<Application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<VisualElements
+		BackgroundColor="#F0EFE7"
+		ShowNameOnSquare150x150Logo="on"
+		ForegroundText="light"/>
+</Application>

--- a/bin/wish.VisualElementsManifest.xml
+++ b/bin/wish.VisualElementsManifest.xml
@@ -1,0 +1,6 @@
+<Application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<VisualElements
+		BackgroundColor="#F0EFE7"
+		ShowNameOnSquare150x150Logo="on"
+		ForegroundText="light"/>
+</Application>

--- a/share/WinGit/copy-files.sh
+++ b/share/WinGit/copy-files.sh
@@ -46,10 +46,10 @@ du.exe,echo,egrep,env.exe,expr.exe,false.exe,find.exe,flex.exe,gawk.exe,grep.exe
 head.exe,id.exe,kill.exe,less.exe,libW11.dll,ln.exe,\
 ls.exe,m4.exe,md5sum.exe,mkdir.exe,msys-1.0.dll,msysltdl-3.dll,mv.exe,patch.exe,\
 patch.exe.manifest,perl.exe,printf,ps.exe,pwd,recodetree,rm.exe,rmdir.exe,rxvt.exe,\
-scp.exe,sed.exe,sh.exe,sleep.exe,sort.exe,split.exe,\
+scp.exe,sed.exe,sh.exe,sh.VisualElementsManifest.xml,sleep.exe,sort.exe,split.exe,\
 ssh-agent.exe,ssh.exe,ssh-add.exe,ssh-keygen.exe,ssh-keyscan.exe,\
 tail.exe,tar.exe,tee.exe,touch.exe,tr.exe,true.exe,uname.exe,uniq.exe,\
-unzip.exe,vi,\
+unzip.exe,vi,wish.VisualElementsManifest.xml,\
 msys-perl5_8.dll,lib{apr,aprutil,expat,neon,z,svn}*.dll,pthreadGC2.dll,\
 msys-crypto-1.0.0.dll,msys-regex-1.dll,msys-ssl-1.0.0.dll,msys-minires.dll,msys-z.dll,\
 vim,vimtutor,wc.exe,which,xargs.exe,start} lib/engines/ \


### PR DESCRIPTION
Windows 8.1 automatically determines the background color, which is not always sensible.
The background is also orange, which gives no contrast to the main content.
![win8gittile1](https://cloud.githubusercontent.com/assets/791115/5517210/f4c20e56-8910-11e4-93fc-adecdf239d11.png)

With this patch, a fixed background color is set. This makes the main content more clear.
![win8gittile2](https://cloud.githubusercontent.com/assets/791115/5517211/f882bad6-8910-11e4-9132-fd543ed570be.png)
