### PR TITLE
Update git-cmd.bat to be compatible with console emulator applications like Console2 and ConEmu.

### DIFF
--- a/git-cmd.bat
+++ b/git-cmd.bat
@@ -13,4 +13,4 @@
 @if not defined TERM set TERM=msys
 
 @cd /d %HOME%
-@start %COMSPEC%
+@call %COMSPEC%


### PR DESCRIPTION
Replaced *start* with *call* so this batch could be used to start msysgit inside console emulators like Console2 or ConEmu. 
The only difference between *start* and *call* that I know is that *call* runs the batch script inside the same shell instance while *start* creates a new shell instance resulting in inability for console emulator to intercept the launch.

Here is an excerpt from **TechNet Command Line** help:

[Call](https://technet.microsoft.com/en-us/library/bb491005.aspx):
> Calls one batch program from another without stopping the parent batch program. The call command accepts labels as the target of the call. Call has no effect at the command-line when used outside of a script or batch file. 

[Start](https://technet.microsoft.com/en-us/library/bb491005.aspx):
> Starts a separate Command Prompt window to run a specified program or command. Used without parameters, start opens a second command prompt window.