### PR TITLE
 make vimdiff be able to be called by git mergetool 

### DIFF
--- a/bin/vimdiff
+++ b/bin/vimdiff
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /share/vim/vim74/vim -d "$@"


### PR DESCRIPTION
git mergetool does not work by default even though vimdiff (one of the
tools it tries to use by default) is installed. vimdiff can be called as
vim -d but not vimdiff from the shell.

Options:
1. call manually as vim -d
more things for user. I think I used this method like this:
    git mergetool --tool="vim -d"

2. link vimdiff to vim (a bit involved on Windows see [Symlinks])
3. make vimdiff.exe call vim.exe
seems slighty more complex but I don't know how all of msysgit
works

4. copy bin/vim to bin/vimdiff (requires adding -d options to exec
call)

I have attached a patch that does number four, since it is the least
complicated with the current features of the program, and makes seem
like the way it works on Linux (defaultable). the -d option on the exec
call is only neccesary because it calls the vim binary, not one called
vimdiff, if there was one called vimdiff it would not be needed, but
this method makes a script called vimdiff call vim -d.

Research:
How it works on OpenBSD:

$ ls -l `which vimdiff`
lrwxr-xr-x 1 root wheel 3 Dec 12 15:54 /usr/local/bin/vimdiff@ -> vim

I looked up how vimdiff work on nix: it is a symbolic link and vim looks
at what it was called as ("argv[0]") to determine some functionality
[1].  So a plain call to to vimdiff with no options works if it points
to the normal binary.

If you were making a symbolic link you might do

$ ln -s share/vim/vim74/vim.exe share/vim/vim74/vimdiff.exe

Symlinks:
I read symbolic links don't work in Git for Windows.

Well, they are a little complicated: Not all versions of windows support
symbolic links (Vista and later), and by default the require admin
privledges to create[3].  There is a script to convert to and from
Windows symbolic links, but that makes things a little more complicated.
If it was already included in Windows for Git it could be used but if
this is the only need for it currently, it may be excessive (and it
wouldn't work on Windows setups).

[1] http://stackoverflow.com/questions/8876323/how-does-the-softlink-vimdiff-be-implemented
[2] http://www.quora.com/How-does-git-handle-symbolic-links-on-Windows
[3] http://stackoverflow.com/questions/5917249/git-symlinks-in-windows