### PR TITLE
ssh-agent: only ask for password if not already loaded

### DIFF
--- a/cmd/start-ssh-agent.cmd
+++ b/cmd/start-ssh-agent.cmd
@@ -58,6 +58,7 @@ if exist "%GIT%" (
         )
     )
     rem See if we have the key
+    set "HOME=%USERPROFILE%"
     "!SSH_ADD!" -l 1>nul 2>nul
     set result=!ERRORLEVEL!
     if not !result! == 0 (
@@ -70,7 +71,6 @@ if exist "%GIT%" (
             )
             echo. done
         )
-        set "HOME=%USERPROFILE%"
         "!SSH_ADD!"
         echo.
     )

--- a/cmd/start-ssh-agent.cmd
+++ b/cmd/start-ssh-agent.cmd
@@ -58,7 +58,7 @@ if exist "%GIT%" (
         )
     )
     rem See if we have the key
-    "!SSH_ADD!" 1>nul 2>nul
+    "!SSH_ADD!" -l 1>nul 2>nul
     set result=!ERRORLEVEL!
     if not !result! == 0 (
         if !result! == 2 (


### PR DESCRIPTION
Running ssh-add.exe with no params will always return an error level to make the script ask for the key's password again.  If ssh-add.exe is run with "-l" then it will set error level properly about loaded keys and only re-add key when necessary.

HOME should be set no matter if we need to add key or it's already present; this shell's environment won't have it set.