### PR TITLE
Make text on Windows 8.1 tiles legible.

### DIFF
--- a/bin/sh.VisualElementsManifest.xml
+++ b/bin/sh.VisualElementsManifest.xml
@@ -2,5 +2,5 @@
 	<VisualElements
 		BackgroundColor="#F0EFE7"
 		ShowNameOnSquare150x150Logo="on"
-		ForegroundText="light"/>
+		ForegroundText="dark"/>
 </Application>

--- a/bin/wish.VisualElementsManifest.xml
+++ b/bin/wish.VisualElementsManifest.xml
@@ -2,5 +2,5 @@
 	<VisualElements
 		BackgroundColor="#F0EFE7"
 		ShowNameOnSquare150x150Logo="on"
-		ForegroundText="light"/>
+		ForegroundText="dark"/>
 </Application>


### PR DESCRIPTION
#270 set the background color to #F0EFE7 (light beige); however, it also set the foreground text to 'light'. When you pin it as a tile to the start menu, this makes the text completely unreadable.
![win81-git-tile](https://cloud.githubusercontent.com/assets/2261204/7716092/4940fdd2-fe5c-11e4-9526-57e5306f324b.png)
This commit sets the text to 'dark', which is a significant improvement.